### PR TITLE
Centralize the count of $locales_array

### DIFF
--- a/files/includes/templates/YOUR_TEMPLATE/jscript/jscript_plugin_structured_data.php
+++ b/files/includes/templates/YOUR_TEMPLATE/jscript/jscript_plugin_structured_data.php
@@ -453,11 +453,11 @@ $locales_array = array_map('trim', $locales_array);
     [3] => es_ES
 )
 */
-if (count($locales_array) > 1 && (count($locales_array) % 2 === 0)) { // is more than one value and is actually a pair
+$locale_count = count($locales_array);
+if ($locale_count > 1 && ($locale_count % 2 === 0)) { // is more than one value and is actually a pair
     $locales_keys_array = [];
     $locales_values_array = [];
     $i = 0;
-    $locale_count = count($locales_array);
     while ($i < $locale_count) {
         $locales_keys_array [] = $locales_array[$i]; // returns: 1,2 etc.
         $i += 2;


### PR DESCRIPTION
Seeing that this variable is `count`ed multiple times, especially in
initial testing for use, seems to make sense to just count the array
once and then use the value of that count where needed.

There might be other variables that could benefit from this; however,
the correction of this PR was all visible within a few lines of code.